### PR TITLE
fix: improve onChange callback performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+yarn.lock


### PR DESCRIPTION
- Only call onChange callback when `inViewport` value changed
- Fix the issue with incorrect measures on Android
- Add `onChange` to useEffect dependency to allow the callback function to update its scope

Example
```tsx
const [count, setCount] = useState(1);

useEffect(() => {
   setCount(2)
},[])

const handleViewPortChange = (isInViewport: boolean) => {
    console.log(count) // --> issue: always return 1
}

<ViewPortDetector onChange={handleViewPortChange}>
  {//...children}
</ViewPortDetector>
```