### PR TITLE
fix(type error): initialise useRef

### DIFF
--- a/components/ViewPortDetector.tsx
+++ b/components/ViewPortDetector.tsx
@@ -74,8 +74,8 @@ export const ViewPortDetector: React.FC<Props> = ({
   const view = useRef<View>(null);
   const { parentLayout } = useContext(ViewPortDetectorContext);
   const isFirstLayout = useRef(true);
-  const timeoutRef = useRef<NodeJS.Timeout>();
-  const intervalRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout>(undefined);
+  const intervalRef = useRef<NodeJS.Timeout>(undefined);
   const isMounted = useRef(true);
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 


### PR DESCRIPTION
**React 19** has some[ breaking changes](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument) regarding the `useRef` types. Each `useRef` must have an initial value.

This PR fixes the type errors.
